### PR TITLE
Fix sitemap URL

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://laleworks.github.io/DAM-DAW/index.html</loc>
-  <lastmod>2025-06-04</lastmod>
+    <loc>https://laleworks.github.io/DAM-DAW/</loc>
+    <lastmod>2025-06-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.00</priority>
   </url>


### PR DESCRIPTION
## Summary
- use canonical URL in sitemap

## Testing
- `xmllint --noout sitemap.xml`

------
https://chatgpt.com/codex/tasks/task_e_684061f4b7a0832b828fc85af06bd0c0