### PR TITLE
Add colorful logo icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
   <meta name="theme-color" content="#4caf50">
 
   <!-- Social images -->
-  <meta property="og:image" content="https://laleworks.github.io/DAM-DAW/favicon.ico">
-  <meta property="og:image:alt" content="LaLeWorks favicon">
-  <meta name="twitter:image" content="https://laleworks.github.io/DAM-DAW/favicon.ico">
+  <meta property="og:image" content="https://laleworks.github.io/DAM-DAW/logo.svg">
+  <meta property="og:image:alt" content="LaLeWorks logo">
+  <meta name="twitter:image" content="https://laleworks.github.io/DAM-DAW/logo.svg">
 
   <!-- Prefetch / Preconnect -->
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">

--- a/logo.svg
+++ b/logo.svg
@@ -1,4 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#4caf50"/>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff5722"/>
+      <stop offset="50%" stop-color="#4caf50"/>
+      <stop offset="100%" stop-color="#2196f3"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="10" fill="url(#grad)"/>
   <text x="32" y="42" font-size="28" font-family="sans-serif" text-anchor="middle" fill="#fff">D&amp;D</text>
 </svg>


### PR DESCRIPTION
## Summary
- redesign logo.svg with a colorful gradient
- reference the new logo in social meta tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684154052e54832bb73e067dcf820747